### PR TITLE
refactor(drivers): dynamically calculated driver classes based on the drivers birth date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "msf-training",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "msf-training",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "hasInstallScript": true,
       "dependencies": {
         "@mantine/core": "^9.2.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "msf-training",
   "productName": "MSF Training",
   "description": "Tools for organizing and managing Kartslalom training sessions by MSF Plettenberg 1930 e.V. im DMV.",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": "Tim Deres",
   "main": "app/main.js",
   "type": "module",

--- a/renderer/lib/constants.ts
+++ b/renderer/lib/constants.ts
@@ -97,8 +97,16 @@ export const CLASS_AGE_TABLE = {
 export const MIN_DRIVER_AGE = 5; // years
 export const MAX_DRIVER_AGE = 99; // years
 
-export const MIN_JKS_DRIVER_AGE = JKS_CLASS_AGE_RANGES[0].min; // years
-export const MIN_SKS_DRIVER_AGE = SKS_CLASS_AGE_RANGES[1].min; // years
+export const MIN_JKS_DRIVER_AGE = Math.min(
+  //
+  // Take all minimum ages from all JKS classes to determine the minimum age for JKS.
+  //
+  ...Object.values(JKS_CLASS_AGE_RANGES).map((r) => r.min),
+); // years
+
+export const MIN_SKS_DRIVER_AGE = Math.min(
+  ...Object.values(SKS_CLASS_AGE_RANGES).map((r) => r.min),
+); // years
 
 export const TIME_PENALTIES_JKS = {
   HIT_CONE: 2, // seconds

--- a/renderer/lib/constants.ts
+++ b/renderer/lib/constants.ts
@@ -97,17 +97,6 @@ export const CLASS_AGE_TABLE = {
 export const MIN_DRIVER_AGE = 5; // years
 export const MAX_DRIVER_AGE = 99; // years
 
-export const MIN_JKS_DRIVER_AGE = Math.min(
-  //
-  // Take all minimum ages from all JKS classes to determine the minimum age for JKS.
-  //
-  ...Object.values(JKS_CLASS_AGE_RANGES).map((r) => r.min),
-); // years
-
-export const MIN_SKS_DRIVER_AGE = Math.min(
-  ...Object.values(SKS_CLASS_AGE_RANGES).map((r) => r.min),
-); // years
-
 export const TIME_PENALTIES_JKS = {
   HIT_CONE: 2, // seconds
   MISSED_GATE: 10, // seconds

--- a/renderer/lib/constants.ts
+++ b/renderer/lib/constants.ts
@@ -97,6 +97,9 @@ export const CLASS_AGE_TABLE = {
 export const MIN_DRIVER_AGE = 5; // years
 export const MAX_DRIVER_AGE = 99; // years
 
+export const MIN_JKS_DRIVER_AGE = JKS_CLASS_AGE_RANGES[0].min; // years
+export const MIN_SKS_DRIVER_AGE = SKS_CLASS_AGE_RANGES[1].min; // years
+
 export const TIME_PENALTIES_JKS = {
   HIT_CONE: 2, // seconds
   MISSED_GATE: 10, // seconds

--- a/renderer/lib/database/getDatabase.ts
+++ b/renderer/lib/database/getDatabase.ts
@@ -45,6 +45,15 @@ export default async function getDatabase() {
         });
       });
   });
+  // Remove driver class from the database since it can be calculated from the birth date
+  db.version(3).upgrade((tx) => {
+    return tx
+      .table('drivers')
+      .toCollection()
+      .modify((driver) => {
+        delete driver.driverClass;
+      });
+  });
 
   instance = db;
   return instance;

--- a/renderer/lib/database/index.ts
+++ b/renderer/lib/database/index.ts
@@ -32,4 +32,14 @@ database.version(2).upgrade((tx) => {
     });
 });
 
+// Remove driver class from the database since it can be calculated from the birth date
+database.version(3).upgrade((tx) => {
+  return tx
+    .table('drivers')
+    .toCollection()
+    .modify((driver) => {
+      delete driver.driverClass;
+    });
+});
+
 export default database;

--- a/renderer/lib/misc/getDriverClass.ts
+++ b/renderer/lib/misc/getDriverClass.ts
@@ -20,24 +20,24 @@ const getClassByAge = ({
       return Number(classKey);
     }
   }
-  return null;
+  return '-';
 };
 
-const getJksClass = ({ birthDate }: DriverBirthDate): number | null => {
+const getJksClass = ({ birthDate }: DriverBirthDate): number | '-' => {
   const age = calculateDriverAgeBasedOfBirthYear(birthDate);
 
   if (!age || isNaN(age)) {
-    return null;
+    return '-';
   }
 
   return getClassByAge({ age, classTable: CLASS_AGE_TABLE.JKS });
 };
 
-const getSksClass = ({ birthDate }: DriverBirthDate): number | null => {
+const getSksClass = ({ birthDate }: DriverBirthDate): number | '-' => {
   const age = calculateDriverAgeBasedOfBirthYear(birthDate);
 
   if (!age || isNaN(age)) {
-    return null;
+    return '-';
   }
 
   return getClassByAge({ age, classTable: CLASS_AGE_TABLE.SKS });

--- a/renderer/lib/training/selectors.test.ts
+++ b/renderer/lib/training/selectors.test.ts
@@ -26,7 +26,6 @@ const createDriver = (uuid: string, laps: Lap[]): DriverWithStints => ({
   lastName: `Last-${uuid}`,
   birthDate: '2000-01-01',
   sex: 'other',
-  driverClass: { jks: 1, sks: 1 },
   createdAt: 1,
   updatedAt: 1,
   stints: [{ laps }],

--- a/renderer/lib/training/trainingReducer.test.ts
+++ b/renderer/lib/training/trainingReducer.test.ts
@@ -7,7 +7,6 @@ const createDriver = (uuid: string): DriverWithStints => ({
   lastName: `Last-${uuid}`,
   birthDate: '2000-01-01',
   sex: 'other',
-  driverClass: { jks: 1, sks: 1 },
   createdAt: 1,
   updatedAt: 1,
   stints: [],

--- a/renderer/lib/types/Driver.d.ts
+++ b/renderer/lib/types/Driver.d.ts
@@ -4,10 +4,6 @@ type Driver = {
   birthDate: string; // ISO 8601 format: YYYY-MM-DD
   // "other" can be used for non-binary, undisclosed, or unspecified sex
   sex: 'male' | 'female' | 'other';
-  driverClass: {
-    jks: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7;
-    sks: 1 | 2 | 3 | 4 | 5;
-  };
   uuid: string; // UUID v4
   createdAt: number; // Unix timestamp
   updatedAt: number; // Unix timestamp

--- a/renderer/pages/drivers/create/index.tsx
+++ b/renderer/pages/drivers/create/index.tsx
@@ -2,7 +2,6 @@ import Layout from '@/components/shared/Layout';
 import PageHeader from '@/components/shared/PageHeader';
 import { GENDER_OPTIONS } from '@/lib/constants';
 import database from '@/lib/database';
-import { getJksClass, getSksClass } from '@/lib/misc/getDriverClass';
 import { Button, Card, Group, NativeSelect, Stack, Text, TextInput } from '@mantine/core';
 import { DateInput } from '@mantine/dates';
 import { hasLength, isInRange, isNotEmpty, useForm } from '@mantine/form';
@@ -14,17 +13,10 @@ import { v4 as uuidv4 } from 'uuid';
 import { MIN_DRIVER_AGE, MAX_DRIVER_AGE } from '@/lib/constants';
 import calculateDriverAge from '@/lib/misc/calculateDriverAge';
 import PageContent from '@/components/shared/PageContent';
-import { useState } from 'react';
 import Stat from '@/components/shared/Stat';
+import { getJksClass, getSksClass } from '@/lib/misc/getDriverClass';
 
 const CreateDriverPage = () => {
-  const [driverClasses, setDriverClasses] = useState<{
-    jks: string | number;
-    sks: string | number;
-  }>({
-    jks: '-',
-    sks: '-',
-  });
   const router = useRouter();
   const form = useForm<Driver>({
     initialValues: {
@@ -55,14 +47,6 @@ const CreateDriverPage = () => {
 
   const handleBirthDateChange = (date: string) => {
     form.getInputProps('birthDate').onChange(date);
-
-    const classJKS = getJksClass({ birthDate: date });
-    const classSKS = getSksClass({ birthDate: date });
-
-    setDriverClasses({
-      jks: classJKS,
-      sks: classSKS,
-    });
   };
 
   const handleCreateDriver = () => {
@@ -147,13 +131,17 @@ const CreateDriverPage = () => {
               <Card>
                 <Stat
                   label="JKS"
-                  value={driverClasses.jks === '-' ? '-' : `K${driverClasses.jks}`}
+                  value={
+                    form.values.birthDate ? getJksClass({ birthDate: form.values.birthDate }) : '-'
+                  }
                 />
               </Card>
               <Card>
                 <Stat
                   label="SKS"
-                  value={driverClasses.sks === '-' ? '-' : `K${driverClasses.sks}`}
+                  value={
+                    form.values.birthDate ? getSksClass({ birthDate: form.values.birthDate }) : '-'
+                  }
                 />
               </Card>
             </Group>

--- a/renderer/pages/drivers/create/index.tsx
+++ b/renderer/pages/drivers/create/index.tsx
@@ -1,6 +1,12 @@
 import Layout from '@/components/shared/Layout';
 import PageHeader from '@/components/shared/PageHeader';
-import { GENDER_OPTIONS, JKS_CLASSES, SKS_CLASSES } from '@/lib/constants';
+import {
+  GENDER_OPTIONS,
+  JKS_CLASSES,
+  MIN_JKS_DRIVER_AGE,
+  MIN_SKS_DRIVER_AGE,
+  SKS_CLASSES,
+} from '@/lib/constants';
 import database from '@/lib/database';
 import { getJksClass, getSksClass } from '@/lib/misc/getDriverClass';
 import { Button, Group, NativeSelect, NumberInput, Stack, Text, TextInput } from '@mantine/core';
@@ -90,6 +96,8 @@ const CreateDriverPage = () => {
     });
   };
 
+  const driverAge = calculateDriverAge(form.values.birthDate) ?? 0;
+
   return (
     <Layout currentRoute="/drivers">
       <PageContent>
@@ -138,6 +146,7 @@ const CreateDriverPage = () => {
             </Group>
             <Group grow>
               <NumberInput
+                disabled={driverAge < MIN_JKS_DRIVER_AGE || !form.values.birthDate}
                 description="Die JKS-Klasse wird automatisch basierend auf dem Geburtsdatum berechnet. Kann allerdings manuell angepasst werden."
                 min={Math.min(...JKS_CLASSES)}
                 max={Math.max(...JKS_CLASSES)}
@@ -146,6 +155,7 @@ const CreateDriverPage = () => {
                 key={form.key('driverClass.jks')}
               />
               <NumberInput
+                disabled={driverAge < MIN_SKS_DRIVER_AGE || !form.values.birthDate}
                 description="Die SKS-Klasse wird automatisch basierend auf dem Geburtsdatum berechnet. Kann allerdings manuell angepasst werden."
                 min={Math.min(...SKS_CLASSES)}
                 max={Math.max(...SKS_CLASSES)}

--- a/renderer/pages/drivers/create/index.tsx
+++ b/renderer/pages/drivers/create/index.tsx
@@ -1,15 +1,9 @@
 import Layout from '@/components/shared/Layout';
 import PageHeader from '@/components/shared/PageHeader';
-import {
-  GENDER_OPTIONS,
-  JKS_CLASSES,
-  MIN_JKS_DRIVER_AGE,
-  MIN_SKS_DRIVER_AGE,
-  SKS_CLASSES,
-} from '@/lib/constants';
+import { GENDER_OPTIONS } from '@/lib/constants';
 import database from '@/lib/database';
 import { getJksClass, getSksClass } from '@/lib/misc/getDriverClass';
-import { Button, Group, NativeSelect, NumberInput, Stack, Text, TextInput } from '@mantine/core';
+import { Button, Card, Group, NativeSelect, Stack, Text, TextInput } from '@mantine/core';
 import { DateInput } from '@mantine/dates';
 import { hasLength, isInRange, isNotEmpty, useForm } from '@mantine/form';
 import { modals } from '@mantine/modals';
@@ -20,8 +14,17 @@ import { v4 as uuidv4 } from 'uuid';
 import { MIN_DRIVER_AGE, MAX_DRIVER_AGE } from '@/lib/constants';
 import calculateDriverAge from '@/lib/misc/calculateDriverAge';
 import PageContent from '@/components/shared/PageContent';
+import { useState } from 'react';
+import Stat from '@/components/shared/Stat';
 
 const CreateDriverPage = () => {
+  const [driverClasses, setDriverClasses] = useState<{
+    jks: string | number;
+    sks: string | number;
+  }>({
+    jks: '-',
+    sks: '-',
+  });
   const router = useRouter();
   const form = useForm<Driver>({
     initialValues: {
@@ -56,8 +59,10 @@ const CreateDriverPage = () => {
     const classJKS = getJksClass({ birthDate: date });
     const classSKS = getSksClass({ birthDate: date });
 
-    form.setFieldValue('driverClass.jks', classJKS);
-    form.setFieldValue('driverClass.sks', classSKS);
+    setDriverClasses({
+      jks: classJKS,
+      sks: classSKS,
+    });
   };
 
   const handleCreateDriver = () => {
@@ -91,8 +96,6 @@ const CreateDriverPage = () => {
       onConfirm: () => router.push('/drivers'),
     });
   };
-
-  const driverAge = calculateDriverAge(form.values.birthDate) ?? 0;
 
   return (
     <Layout currentRoute="/drivers">
@@ -141,24 +144,18 @@ const CreateDriverPage = () => {
               />
             </Group>
             <Group grow>
-              <NumberInput
-                disabled={driverAge < MIN_JKS_DRIVER_AGE || !form.values.birthDate}
-                description="Die JKS-Klasse wird automatisch basierend auf dem Geburtsdatum berechnet. Kann allerdings manuell angepasst werden."
-                min={Math.min(...JKS_CLASSES)}
-                max={Math.max(...JKS_CLASSES)}
-                label="Klasse JKS"
-                {...form.getInputProps('driverClass.jks')}
-                key={form.key('driverClass.jks')}
-              />
-              <NumberInput
-                disabled={driverAge < MIN_SKS_DRIVER_AGE || !form.values.birthDate}
-                description="Die SKS-Klasse wird automatisch basierend auf dem Geburtsdatum berechnet. Kann allerdings manuell angepasst werden."
-                min={Math.min(...SKS_CLASSES)}
-                max={Math.max(...SKS_CLASSES)}
-                label="Klasse SKS"
-                {...form.getInputProps('driverClass.sks')}
-                key={form.key('driverClass.sks')}
-              />
+              <Card>
+                <Stat
+                  label="JKS"
+                  value={driverClasses.jks === '-' ? '-' : `K${driverClasses.jks}`}
+                />
+              </Card>
+              <Card>
+                <Stat
+                  label="SKS"
+                  value={driverClasses.sks === '-' ? '-' : `K${driverClasses.sks}`}
+                />
+              </Card>
             </Group>
             <Group mt="xl">
               <Button type="submit">Fahrer erstellen</Button>

--- a/renderer/pages/drivers/create/index.tsx
+++ b/renderer/pages/drivers/create/index.tsx
@@ -29,10 +29,6 @@ const CreateDriverPage = () => {
       lastName: '',
       birthDate: '',
       sex: 'male',
-      driverClass: {
-        jks: 0,
-        sks: 1,
-      },
       uuid: uuidv4(),
       createdAt: Date.now(),
       updatedAt: Date.now(),
@@ -60,8 +56,8 @@ const CreateDriverPage = () => {
     const classJKS = getJksClass({ birthDate: date });
     const classSKS = getSksClass({ birthDate: date });
 
-    form.setFieldValue('driverClass.jks', classJKS as Driver['driverClass']['jks']);
-    form.setFieldValue('driverClass.sks', classSKS as Driver['driverClass']['sks']);
+    form.setFieldValue('driverClass.jks', classJKS);
+    form.setFieldValue('driverClass.sks', classSKS);
   };
 
   const handleCreateDriver = () => {

--- a/renderer/pages/drivers/edit/[uuid].tsx
+++ b/renderer/pages/drivers/edit/[uuid].tsx
@@ -1,35 +1,28 @@
 import Layout from '@/components/shared/Layout';
 import PageContent from '@/components/shared/PageContent';
 import PageHeader from '@/components/shared/PageHeader';
-import {
-  GENDER_OPTIONS,
-  JKS_CLASSES,
-  MIN_JKS_DRIVER_AGE,
-  MIN_SKS_DRIVER_AGE,
-  SKS_CLASSES,
-} from '@/lib/constants';
+import Stat from '@/components/shared/Stat';
+import { GENDER_OPTIONS } from '@/lib/constants';
 import database from '@/lib/database';
-import calculateDriverAge from '@/lib/misc/calculateDriverAge';
 import { getJksClass, getSksClass } from '@/lib/misc/getDriverClass';
-import {
-  Button,
-  Group,
-  NativeSelect,
-  NumberInput,
-  Stack,
-  TextInput,
-  Text,
-  Title,
-} from '@mantine/core';
+import { Button, Group, NativeSelect, Stack, TextInput, Text, Title, Card } from '@mantine/core';
 import { DateInput } from '@mantine/dates';
 import { useForm } from '@mantine/form';
 import { modals } from '@mantine/modals';
 import { notifications } from '@mantine/notifications';
 import { useLiveQuery } from 'dexie-react-hooks';
 import { useRouter } from 'next/router';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 const DriverEditPage = () => {
+  const [driverClasses, setDriverClasses] = useState<{
+    jks: string | number;
+    sks: string | number;
+  }>({
+    jks: '-',
+    sks: '-',
+  });
+
   const router = useRouter();
   const { uuid } = router.query;
 
@@ -58,7 +51,15 @@ const DriverEditPage = () => {
       createdAt: driver.createdAt,
       updatedAt: driver.updatedAt,
     });
-    // Make
+
+    const classJKS = getJksClass({ birthDate: driver.birthDate });
+    const classSKS = getSksClass({ birthDate: driver.birthDate });
+
+    setDriverClasses({
+      jks: classJKS,
+      sks: classSKS,
+    });
+
     form.resetDirty();
     form.resetTouched();
   }, [driver]);
@@ -109,8 +110,10 @@ const DriverEditPage = () => {
     const classJKS = getJksClass({ birthDate: date });
     const classSKS = getSksClass({ birthDate: date });
 
-    form.setFieldValue('driverClass.jks', classJKS);
-    form.setFieldValue('driverClass.sks', classSKS);
+    setDriverClasses({
+      jks: classJKS,
+      sks: classSKS,
+    });
   };
 
   const handleEditDriver = () => {
@@ -133,8 +136,6 @@ const DriverEditPage = () => {
         router.push('/drivers');
       });
   };
-
-  const driverAge = calculateDriverAge(form.values.birthDate) ?? 0;
 
   return (
     <Layout currentRoute="/drivers">
@@ -182,24 +183,18 @@ const DriverEditPage = () => {
               />
             </Group>
             <Group grow>
-              <NumberInput
-                disabled={driverAge < MIN_JKS_DRIVER_AGE || !form.values.birthDate}
-                description="Die JKS-Klasse wird automatisch basierend auf dem Geburtsdatum berechnet. Kann allerdings manuell angepasst werden."
-                min={Math.min(...JKS_CLASSES)}
-                max={Math.max(...JKS_CLASSES)}
-                label="Klasse JKS"
-                {...form.getInputProps('driverClass.jks')}
-                key={form.key('driverClass.jks')}
-              />
-              <NumberInput
-                disabled={driverAge < MIN_SKS_DRIVER_AGE || !form.values.birthDate}
-                description="Die SKS-Klasse wird automatisch basierend auf dem Geburtsdatum berechnet. Kann allerdings manuell angepasst werden."
-                min={Math.min(...SKS_CLASSES)}
-                max={Math.max(...SKS_CLASSES)}
-                label="Klasse SKS"
-                {...form.getInputProps('driverClass.sks')}
-                key={form.key('driverClass.sks')}
-              />
+              <Card>
+                <Stat
+                  label="JKS"
+                  value={driverClasses.jks === '-' ? '-' : `K${driverClasses.jks}`}
+                />
+              </Card>
+              <Card>
+                <Stat
+                  label="SKS"
+                  value={driverClasses.sks === '-' ? '-' : `K${driverClasses.sks}`}
+                />
+              </Card>
             </Group>
             <Group mt="xl">
               <Button type="submit">Änderungen speichern</Button>

--- a/renderer/pages/drivers/edit/[uuid].tsx
+++ b/renderer/pages/drivers/edit/[uuid].tsx
@@ -12,17 +12,9 @@ import { modals } from '@mantine/modals';
 import { notifications } from '@mantine/notifications';
 import { useLiveQuery } from 'dexie-react-hooks';
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
 const DriverEditPage = () => {
-  const [driverClasses, setDriverClasses] = useState<{
-    jks: string | number;
-    sks: string | number;
-  }>({
-    jks: '-',
-    sks: '-',
-  });
-
   const router = useRouter();
   const { uuid } = router.query;
 
@@ -50,14 +42,6 @@ const DriverEditPage = () => {
       uuid: driver.uuid,
       createdAt: driver.createdAt,
       updatedAt: driver.updatedAt,
-    });
-
-    const classJKS = getJksClass({ birthDate: driver.birthDate });
-    const classSKS = getSksClass({ birthDate: driver.birthDate });
-
-    setDriverClasses({
-      jks: classJKS,
-      sks: classSKS,
     });
 
     form.resetDirty();
@@ -106,14 +90,6 @@ const DriverEditPage = () => {
 
   const handleBirthDateChange = (date: string) => {
     form.getInputProps('birthDate').onChange(date);
-
-    const classJKS = getJksClass({ birthDate: date });
-    const classSKS = getSksClass({ birthDate: date });
-
-    setDriverClasses({
-      jks: classJKS,
-      sks: classSKS,
-    });
   };
 
   const handleEditDriver = () => {
@@ -186,13 +162,17 @@ const DriverEditPage = () => {
               <Card>
                 <Stat
                   label="JKS"
-                  value={driverClasses.jks === '-' ? '-' : `K${driverClasses.jks}`}
+                  value={
+                    form.values.birthDate ? getJksClass({ birthDate: form.values.birthDate }) : '-'
+                  }
                 />
               </Card>
               <Card>
                 <Stat
                   label="SKS"
-                  value={driverClasses.sks === '-' ? '-' : `K${driverClasses.sks}`}
+                  value={
+                    form.values.birthDate ? getSksClass({ birthDate: form.values.birthDate }) : '-'
+                  }
                 />
               </Card>
             </Group>

--- a/renderer/pages/drivers/edit/[uuid].tsx
+++ b/renderer/pages/drivers/edit/[uuid].tsx
@@ -1,8 +1,15 @@
 import Layout from '@/components/shared/Layout';
 import PageContent from '@/components/shared/PageContent';
 import PageHeader from '@/components/shared/PageHeader';
-import { GENDER_OPTIONS, JKS_CLASSES, SKS_CLASSES } from '@/lib/constants';
+import {
+  GENDER_OPTIONS,
+  JKS_CLASSES,
+  MIN_JKS_DRIVER_AGE,
+  MIN_SKS_DRIVER_AGE,
+  SKS_CLASSES,
+} from '@/lib/constants';
 import database from '@/lib/database';
+import calculateDriverAge from '@/lib/misc/calculateDriverAge';
 import { getJksClass, getSksClass } from '@/lib/misc/getDriverClass';
 import {
   Button,
@@ -129,6 +136,8 @@ const DriverEditPage = () => {
       });
   };
 
+  const driverAge = calculateDriverAge(form.values.birthDate) ?? 0;
+
   return (
     <Layout currentRoute="/drivers">
       <PageContent>
@@ -176,6 +185,7 @@ const DriverEditPage = () => {
             </Group>
             <Group grow>
               <NumberInput
+                disabled={driverAge < MIN_JKS_DRIVER_AGE || !form.values.birthDate}
                 description="Die JKS-Klasse wird automatisch basierend auf dem Geburtsdatum berechnet. Kann allerdings manuell angepasst werden."
                 min={Math.min(...JKS_CLASSES)}
                 max={Math.max(...JKS_CLASSES)}
@@ -184,6 +194,7 @@ const DriverEditPage = () => {
                 key={form.key('driverClass.jks')}
               />
               <NumberInput
+                disabled={driverAge < MIN_SKS_DRIVER_AGE || !form.values.birthDate}
                 description="Die SKS-Klasse wird automatisch basierend auf dem Geburtsdatum berechnet. Kann allerdings manuell angepasst werden."
                 min={Math.min(...SKS_CLASSES)}
                 max={Math.max(...SKS_CLASSES)}

--- a/renderer/pages/drivers/edit/[uuid].tsx
+++ b/renderer/pages/drivers/edit/[uuid].tsx
@@ -39,7 +39,6 @@ const DriverEditPage = () => {
       lastName: '',
       birthDate: '', // ISO string
       sex: 'male',
-      driverClass: { jks: 0, sks: 1 },
       uuid: '',
       createdAt: Date.now(),
       updatedAt: Date.now(),
@@ -55,7 +54,6 @@ const DriverEditPage = () => {
       lastName: driver.lastName,
       birthDate: driver.birthDate,
       sex: driver.sex,
-      driverClass: driver.driverClass,
       uuid: driver.uuid,
       createdAt: driver.createdAt,
       updatedAt: driver.updatedAt,
@@ -111,8 +109,8 @@ const DriverEditPage = () => {
     const classJKS = getJksClass({ birthDate: date });
     const classSKS = getSksClass({ birthDate: date });
 
-    form.setFieldValue('driverClass.jks', classJKS as Driver['driverClass']['jks']);
-    form.setFieldValue('driverClass.sks', classSKS as Driver['driverClass']['sks']);
+    form.setFieldValue('driverClass.jks', classJKS);
+    form.setFieldValue('driverClass.sks', classSKS);
   };
 
   const handleEditDriver = () => {

--- a/renderer/pages/drivers/index.tsx
+++ b/renderer/pages/drivers/index.tsx
@@ -87,34 +87,41 @@ const DriversPage = () => {
           data={{
             head: ['Name', '', 'Geburtsdatum', 'JKS', 'SKS'],
             body: drivers
-              ? drivers.map((driver) => [
-                  <Group gap="md">
-                    <Avatar color="initials" name={`${driver.firstName} ${driver.lastName}`} />
-                    <Text>
-                      {driver.firstName} {driver.lastName}
-                    </Text>
-                  </Group>,
-                  driver.sex === 'male' ? (
-                    <Tooltip label="Männlich" {...DEFAULT_TOOLTIP_PROPS}>
-                      <IconGenderMale />
-                    </Tooltip>
-                  ) : driver.sex === 'female' ? (
-                    <Tooltip label="Weiblich" {...DEFAULT_TOOLTIP_PROPS}>
-                      <IconGenderFemale />
-                    </Tooltip>
-                  ) : (
-                    <Tooltip label="Divers" {...DEFAULT_TOOLTIP_PROPS}>
-                      <IconGenderTransgender />
-                    </Tooltip>
-                  ),
-                  `${new Date(driver.birthDate).toLocaleDateString('de', {
-                    ...DEFAULT_DATE_FORMAT,
-                    month: 'long',
-                  })} (${calculateDriverAge(driver.birthDate)} Jahre)`,
-                  `K${getJksClass({ birthDate: driver.birthDate })}`,
-                  `K${getSksClass({ birthDate: driver.birthDate })}`,
-                  tableActions(driver.uuid),
-                ])
+              ? drivers.map((driver) => {
+                  const jksClass = getJksClass({ birthDate: driver.birthDate });
+                  const sksClass = getSksClass({ birthDate: driver.birthDate });
+                  const jksDisplay = jksClass === '-' ? '-' : `K${jksClass}`;
+                  const sksDisplay = sksClass === '-' ? '-' : `K${sksClass}`;
+
+                  return [
+                    <Group gap="md">
+                      <Avatar color="initials" name={`${driver.firstName} ${driver.lastName}`} />
+                      <Text>
+                        {driver.firstName} {driver.lastName}
+                      </Text>
+                    </Group>,
+                    driver.sex === 'male' ? (
+                      <Tooltip label="Männlich" {...DEFAULT_TOOLTIP_PROPS}>
+                        <IconGenderMale />
+                      </Tooltip>
+                    ) : driver.sex === 'female' ? (
+                      <Tooltip label="Weiblich" {...DEFAULT_TOOLTIP_PROPS}>
+                        <IconGenderFemale />
+                      </Tooltip>
+                    ) : (
+                      <Tooltip label="Divers" {...DEFAULT_TOOLTIP_PROPS}>
+                        <IconGenderTransgender />
+                      </Tooltip>
+                    ),
+                    `${new Date(driver.birthDate).toLocaleDateString('de', {
+                      ...DEFAULT_DATE_FORMAT,
+                      month: 'long',
+                    })} (${calculateDriverAge(driver.birthDate)} Jahre)`,
+                    jksDisplay,
+                    sksDisplay,
+                    tableActions(driver.uuid),
+                  ];
+                })
               : [],
             caption: `${drivers?.length || 0} Fahrer wurden gefunden`,
           }}

--- a/renderer/pages/drivers/view/[uuid].tsx
+++ b/renderer/pages/drivers/view/[uuid].tsx
@@ -84,7 +84,7 @@ const DriverViewPage = () => {
             <Stat label="Geschlecht" value={translateSex(driver.sex)} />
             <Stat label="JKS" value={getJksClass({ birthDate: driver.birthDate })} />
             <Stat label="SKS" value={getSksClass({ birthDate: driver.birthDate })} />
-            <Stat label="Trainings" value={trainings?.length || 0} />
+            <Stat label="Trainings" value={trainings?.length ?? 0} />
           </Group>
         </Card>
         <Divider label="Statistiken" labelPosition="left" />

--- a/renderer/pages/drivers/view/[uuid].tsx
+++ b/renderer/pages/drivers/view/[uuid].tsx
@@ -22,6 +22,7 @@ import { IconCode, IconPencil, IconSearch } from '@tabler/icons-react';
 import { useLiveQuery } from 'dexie-react-hooks';
 import { useRouter } from 'next/router';
 import { formatTime } from '@/lib/time/formatTime';
+import { getJksClass, getSksClass } from '@/lib/misc/getDriverClass';
 
 const DriverViewPage = () => {
   const router = useRouter();
@@ -81,8 +82,8 @@ const DriverViewPage = () => {
               value={new Date(driver.birthDate).toLocaleDateString('de', DEFAULT_DATE_FORMAT)}
             />
             <Stat label="Geschlecht" value={translateSex(driver.sex)} />
-            <Stat label="JKS" value={`K${driver.driverClass.jks}`} />
-            <Stat label="SKS" value={`K${driver.driverClass.sks}`} />
+            <Stat label="JKS" value={getJksClass({ birthDate: driver.birthDate })} />
+            <Stat label="SKS" value={getSksClass({ birthDate: driver.birthDate })} />
             <Stat label="Trainings" value={trainings?.length || 0} />
           </Group>
         </Card>

--- a/renderer/pages/trainings/[uuid]/view.tsx
+++ b/renderer/pages/trainings/[uuid]/view.tsx
@@ -1,6 +1,7 @@
 import Layout from '@/components/shared/Layout';
 import PageContent from '@/components/shared/PageContent';
 import database from '@/lib/database';
+import { getJksClass, getSksClass } from '@/lib/misc/getDriverClass';
 import { formatTime } from '@/lib/time/formatTime';
 import {
   getDiffToBest,
@@ -104,8 +105,8 @@ const TrainingViewPage = () => {
                   <Table.Td>
                     K
                     {training.mode === 'JKS'
-                      ? (driver.driverClass?.jks ?? 7)
-                      : (driver.driverClass?.sks ?? 5)}
+                      ? getJksClass({ birthDate: driver.birthDate })
+                      : getSksClass({ birthDate: driver.birthDate })}
                   </Table.Td>
                   <Table.Td>
                     {driver.firstName} {driver.lastName}

--- a/renderer/pages/trainings/[uuid]/view.tsx
+++ b/renderer/pages/trainings/[uuid]/view.tsx
@@ -10,7 +10,8 @@ import {
   getDriverRanking,
   getFastestLapTimestamp,
 } from '@/lib/training/selectors';
-import { Badge, Code, Stack, Table, Text, Title } from '@mantine/core';
+import { Badge, Code, Divider, Stack, Table, Text, Title, Tooltip } from '@mantine/core';
+import { IconFlagX } from '@tabler/icons-react';
 import { useLiveQuery } from 'dexie-react-hooks';
 import { useRouter } from 'next/router';
 
@@ -84,6 +85,7 @@ const TrainingViewPage = () => {
             <Table.Tr>
               <Table.Th>#</Table.Th>
               <Table.Th>Klasse</Table.Th>
+              <Table.Th>{/* Gender Indicator */}</Table.Th>
               <Table.Th>Fahrer</Table.Th>
               <Table.Th>Bestzeit</Table.Th>
               <Table.Th>Abstand</Table.Th>
@@ -104,13 +106,29 @@ const TrainingViewPage = () => {
                   <Table.Td>{index + 1}.</Table.Td>
                   <Table.Td>
                     K
-                    {training.mode === 'JKS'
-                      ? getJksClass({ birthDate: driver.birthDate })
-                      : getSksClass({ birthDate: driver.birthDate })}
+                    {(() => {
+                      // Preserve the classes as of the training date by shifting the birthDate
+                      // so that the age computed against the current date equals the age at
+                      // the training date.
+                      const trainingMs = new Date(training.createdAt).getTime();
+                      const birthMs = new Date(driver.birthDate).getTime();
+                      let birthForClass: string = String(driver.birthDate);
+
+                      if (!Number.isNaN(trainingMs) && !Number.isNaN(birthMs)) {
+                        const shifted = new Date(Date.now() - (trainingMs - birthMs));
+                        birthForClass = shifted.toISOString();
+                      }
+
+                      return training.mode === 'JKS'
+                        ? getJksClass({ birthDate: birthForClass })
+                        : getSksClass({ birthDate: birthForClass });
+                    })()}
                   </Table.Td>
+                  <Table.Td>{driver.sex === 'female' ? 'D' : undefined}</Table.Td>
                   <Table.Td>
                     {driver.firstName} {driver.lastName}
                   </Table.Td>
+
                   <Table.Td>
                     <Text ff="monospace" fw="bold" c={index === 0 ? 'grape' : ''}>
                       {fastestLap ? formatTime(fastestLap.time_with_penalties, 'lap') : 'N/A'}
@@ -146,22 +164,38 @@ const TrainingViewPage = () => {
               const penaltyMs = Math.max(0, lap.time_with_penalties - lap.time);
 
               return (
-                <Table.Tr key={`${driver.uuid}-${stintIndex}-${lapIndex}`}>
+                <Table.Tr
+                  key={`${driver.uuid}-${stintIndex}-${lapIndex}`}
+                  opacity={lap.isInvalid ? 0.2 : 1}
+                >
                   <Table.Td>{overallLap}</Table.Td>
                   <Table.Td>{stintIndex + 1}</Table.Td>
                   <Table.Td>{lapIndex + 1}</Table.Td>
+                  <Table.Td ff="monospace">
+                    {formatTime(lap.time_with_penalties, 'lap')} &nbsp;
+                  </Table.Td>
                   <Table.Td>
-                    <Badge ff="monospace">{formatTime(lap.time_with_penalties, 'lap')}</Badge>
+                    {lap.time !== lap.time_with_penalties && (
+                      <Text c="red" fz="sm" ff="monospace">
+                        {penaltyMs / 1000}s
+                      </Text>
+                    )}
                   </Table.Td>
                   <Table.Td>{lap.cones}</Table.Td>
                   <Table.Td>{lap.gates}</Table.Td>
-                  {/*<Table.Td>{formatTime(penaltyMs, "gap")}</Table.Td>*/}
                   <Table.Td>
                     {new Date(lap.timestamp).toLocaleTimeString('de', {
                       hour: '2-digit',
                       minute: '2-digit',
                       second: '2-digit',
                     })}
+                  </Table.Td>
+                  <Table.Td w={18 * 2.5}>
+                    {lap.isInvalid ? (
+                      <Tooltip label="Ungültige Runde" withArrow>
+                        <IconFlagX size={18} style={{ cursor: 'help' }} />
+                      </Tooltip>
+                    ) : undefined}
                   </Table.Td>
                 </Table.Tr>
               );
@@ -170,9 +204,12 @@ const TrainingViewPage = () => {
 
           return (
             <div key={driver.uuid}>
-              <Title order={4} mt="md">
-                {driver.firstName} {driver.lastName} — Runden
-              </Title>
+              <Divider
+                mt="xl"
+                mb="md"
+                label={`${driver.firstName} ${driver.lastName}`}
+                labelPosition="center"
+              />
               <Table striped highlightOnHover>
                 <Table.Thead>
                   <Table.Tr>
@@ -180,10 +217,11 @@ const TrainingViewPage = () => {
                     <Table.Th>Stint</Table.Th>
                     <Table.Th>Runde</Table.Th>
                     <Table.Th>Zeit</Table.Th>
-                    <Table.Th>Pylonen-Fehler</Table.Th>
-                    <Table.Th>Tor-Fehler</Table.Th>
-                    {/*<Table.Th>Strafzeit</Table.Th>*/}
+                    <Table.Th>Strafe</Table.Th>
+                    <Table.Th>P</Table.Th>
+                    <Table.Th>T</Table.Th>
                     <Table.Th>Zeitpunkt</Table.Th>
+                    <Table.Th>{/* Invalid Flag */}</Table.Th>
                   </Table.Tr>
                 </Table.Thead>
                 <Table.Tbody>{rows}</Table.Tbody>


### PR DESCRIPTION
This pull request refactors how driver class (JKS/SKS) is determined and stored throughout the application. Instead of persisting the driver class in the database, it is now dynamically calculated based on the driver's birth date. This simplifies data management and ensures class assignments are always up-to-date. The UI is updated to reflect these changes, including disabling class selection for ineligible ages and updating how classes are displayed.

**Database and Data Model Changes:**

* Removed the `driverClass` property from all driver records in the database, as it can now be derived from the birth date. This is handled in a new database migration (version 3). [[1]](diffhunk://#diff-60da1ec5321b65ad1b229eb50cb21adba0422fc6b110545fe300a770de48ea82R48-R56) [[2]](diffhunk://#diff-111f042d9f15b997b2eea58cc11ee7be3f6377334b9fc0fd2653362a0a0af972R35-R44)

**Driver Class Calculation and Usage:**

* Updated all usages of driver class (`jks`, `sks`) to compute the value on the fly using the driver's birth date, including in driver creation, editing, viewing, and training views. [[1]](diffhunk://#diff-dbe3fdd4b0e0236072946a202e5fc12e9c9634fe652c33be344f9a9d7a4568dcL23-R40) [[2]](diffhunk://#diff-d41928bd70cb59e7b7bdfe8e9dec17df1298292a05b7bb4dd566f1d228b2fa14L90-R96) [[3]](diffhunk://#diff-d41928bd70cb59e7b7bdfe8e9dec17df1298292a05b7bb4dd566f1d228b2fa14L114-R124) [renderer/pages/drivers/view/[uuid].tsxR25](diffhunk://#diff-5a2243dcb099260c3f7bb959d6c152e7436cdb468756e60fa94a765ac4f6aaebR25), [renderer/pages/drivers/view/[uuid].tsxL84-R86](diffhunk://#diff-5a2243dcb099260c3f7bb959d6c152e7436cdb468756e60fa94a765ac4f6aaebL84-R86), [renderer/pages/trainings/[uuid]/view.tsxR4](diffhunk://#diff-49b5cdbf7f28926f626ada1ce4d2691f48dd9685a17bc37d4f2124010893fc5dR4), [renderer/pages/trainings/[uuid]/view.tsxL107-R109](diffhunk://#diff-49b5cdbf7f28926f626ada1ce4d2691f48dd9685a17bc37d4f2124010893fc5dL107-R109))

**UI/UX Improvements:**

* Disabled manual class selection in the UI for JKS/SKS if the driver's age is below the minimum allowed, ensuring users cannot select invalid classes. [[1]](diffhunk://#diff-58b529802a0d48c7dab3241811bbd1728c7b1acaacc1b70fa0f3bc7a2cd9f8e5R145) [[2]](diffhunk://#diff-58b529802a0d48c7dab3241811bbd1728c7b1acaacc1b70fa0f3bc7a2cd9f8e5R154) [renderer/pages/drivers/edit/[uuid].tsxR186](diffhunk://#diff-27c94ab620c34ae46eb6318aa3a38c1344bdfb06a2cd867ef820b633ad461f81R186), [renderer/pages/drivers/edit/[uuid].tsxR195](diffhunk://#diff-27c94ab620c34ae46eb6318aa3a38c1344bdfb06a2cd867ef820b633ad461f81R195))
* Updated driver creation and editing forms to remove the `driverClass` field from initial values and form state, reflecting the new dynamic calculation. [[1]](diffhunk://#diff-58b529802a0d48c7dab3241811bbd1728c7b1acaacc1b70fa0f3bc7a2cd9f8e5L26-L29) [[2]](diffhunk://#diff-58b529802a0d48c7dab3241811bbd1728c7b1acaacc1b70fa0f3bc7a2cd9f8e5L57-R60) [renderer/pages/drivers/edit/[uuid].tsxL35](diffhunk://#diff-27c94ab620c34ae46eb6318aa3a38c1344bdfb06a2cd867ef820b633ad461f81L35), [renderer/pages/drivers/edit/[uuid].tsxL51](diffhunk://#diff-27c94ab620c34ae46eb6318aa3a38c1344bdfb06a2cd867ef820b633ad461f81L51), [renderer/pages/drivers/edit/[uuid].tsxL107-R113](diffhunk://#diff-27c94ab620c34ae46eb6318aa3a38c1344bdfb06a2cd867ef820b633ad461f81L107-R113))

**Constants and Utility Updates:**

* Added new constants for minimum driver ages for JKS and SKS classes, and updated related utility functions to use `'-'` instead of `null` when a class cannot be determined. [[1]](diffhunk://#diff-d9288a22d4b7b08671255565bab5d8837a28ceda3f23608d17adf19b5ade0b64R100-R102) [[2]](diffhunk://#diff-dbe3fdd4b0e0236072946a202e5fc12e9c9634fe652c33be344f9a9d7a4568dcL23-R40)

**Test Updates:**

* Removed the `driverClass` field from driver test fixtures to align with the new model. [[1]](diffhunk://#diff-1096099c88009c1bf9f539d0e5488ed595b0c9e9e0f358aaedf5d0c9e60ea1ebL29) [[2]](diffhunk://#diff-cf87c9ab2585fceaf64f8fefb04d1a2b1a1f8d80afa322f2bf7b15dcdb4101deL10)