### PR TITLE
fix(training): better hotkeys & improve keyboard shortcut handling

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,7 +17,7 @@ TODOs for the upcoming releases of the app.
 
 ### Bugs
 
-- [ ] bug: After using the inputs for cones, gates or the invalid lap checkbox, the app keeps focus on the input. This is a problem because it prevents the user from using the keyboard hotkeys.
+- [x] bug: After using the inputs for cones, gates or the invalid lap checkbox, the app keeps focus on the input. This is a problem because it prevents the user from using the keyboard hotkeys.
 - [ ] bug: Sometimes, the keyboard hotkeys stop working. This problem is probably related to the user selecting text or when a overflow happens and the page scrolls. The hotkeys should work regardless of the user interaction with the page.
 - [ ] bug: When the user opens a trainings view, for a split second, shows that for that UUID there is no training, before showing the correct training. This is a problem because it creates a bad user experience and can cause confusion. The app should show a loading state while the training is being fetched, and only show the "no training" message if the training is not found after the loading state is finished.
 - [x] bug: The electron app menu allows the user to open the developer console in production and use the browser specific hotkeys (eg. ctrl + w to close the window). This is a problem because it can cause confusion and can lead to the user accidentally closing the app or opening the developer console. The app menu should be disabled in production, or at least the options that allow the user to open the developer console or use browser specific hotkeys should be disabled. (PR #5)

--- a/TODO.md
+++ b/TODO.md
@@ -18,7 +18,7 @@ TODOs for the upcoming releases of the app.
 ### Bugs
 
 - [x] bug: After using the inputs for cones, gates or the invalid lap checkbox, the app keeps focus on the input. This is a problem because it prevents the user from using the keyboard hotkeys.
-- [ ] bug: Sometimes, the keyboard hotkeys stop working. This problem is probably related to the user selecting text or when a overflow happens and the page scrolls. The hotkeys should work regardless of the user interaction with the page.
+- [x] bug: Sometimes, the keyboard hotkeys stop working. This problem is probably related to the user selecting text or when a overflow happens and the page scrolls. The hotkeys should work regardless of the user interaction with the page.
 - [ ] bug: When the user opens a trainings view, for a split second, shows that for that UUID there is no training, before showing the correct training. This is a problem because it creates a bad user experience and can cause confusion. The app should show a loading state while the training is being fetched, and only show the "no training" message if the training is not found after the loading state is finished.
 - [x] bug: The electron app menu allows the user to open the developer console in production and use the browser specific hotkeys (eg. ctrl + w to close the window). This is a problem because it can cause confusion and can lead to the user accidentally closing the app or opening the developer console. The app menu should be disabled in production, or at least the options that allow the user to open the developer console or use browser specific hotkeys should be disabled. (PR #5)
 

--- a/renderer/hooks/useTraining.ts
+++ b/renderer/hooks/useTraining.ts
@@ -395,8 +395,8 @@ const useTraining = () => {
       ['Q', () => handleStopwatchStart()],
       ['W', () => handleStopwatchLap()],
       ['E', () => handleStopwatchReset()],
-      ['CTRL+S', () => handleUpdateCurrentDriver()],
-      ['CTRL+D', () => handleSkipDriver()],
+      ['MOD+S', () => handleUpdateCurrentDriver()],
+      ['MOD+D', () => handleSkipDriver()],
       // ["ESC", () => handleStopTraining()],
     ],
     // This array is intentionally empty to ensure hotkey

--- a/renderer/hooks/useTraining.ts
+++ b/renderer/hooks/useTraining.ts
@@ -390,14 +390,20 @@ const useTraining = () => {
     };
   }, [stopwatch.isRunning()]);
 
-  useHotkeys([
-    ['Q', () => handleStopwatchStart()],
-    ['W', () => handleStopwatchLap()],
-    ['E', () => handleStopwatchReset()],
-    ['CTRL+S', () => handleUpdateCurrentDriver()],
-    ['CTRL+D', () => handleSkipDriver()],
-    // ["ESC", () => handleStopTraining()],
-  ]);
+  useHotkeys(
+    [
+      ['Q', () => handleStopwatchStart()],
+      ['W', () => handleStopwatchLap()],
+      ['E', () => handleStopwatchReset()],
+      ['CTRL+S', () => handleUpdateCurrentDriver()],
+      ['CTRL+D', () => handleSkipDriver()],
+      // ["ESC", () => handleStopTraining()],
+    ],
+    // This array is intentionally empty to ensure hotkey
+    // events are not ignored on any focused element
+    // (e.g. Checkbox or NumberInput).
+    [],
+  );
 
   return {
     availableDrivers,


### PR DESCRIPTION
This pull request addresses a bug where keyboard hotkeys stopped working after interacting with certain input fields, and also updates the hotkey combination to use a more cross-platform modifier. The main focus is on improving the user experience with keyboard shortcuts in the training view.

Bug fixes and improvements to hotkey handling:

* Marked the bug regarding input focus preventing hotkey use as fixed in `TODO.md`, indicating that the issue where using cones, gates, or invalid lap inputs blocked hotkeys has been resolved.
* Updated the hotkey registration in `useTraining.ts` to use an empty dependency array, ensuring hotkey events are captured regardless of which input element is focused (e.g., checkboxes or number inputs). This prevents the loss of hotkey functionality after interacting with inputs.
* Changed hotkey combinations from `CTRL+S`/`CTRL+D` to `MOD+S`/`MOD+D` in `useTraining.ts` for better cross-platform compatibility (using the Command key on Mac and Control on Windows/Linux).