### PR TITLE
feat(trainings): add inactive flag to training drivers

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,7 @@ TODOs for the upcoming releases of the app.
 
 ### Features
 
-- [ ] feat: When a driver left the training early, the user should be able to mark the driver. So the app automatically skips the driver. This can be done by eg. adding a checkbox. It should be possible to "re-enable" the driver, in case the user marked the driver by accident or the driver wants to continue the training later. Also drivers, that left the training should be "grayed out" in the UI, so the user can easily see which drivers are still active in the training and which drivers left the training.
+- [x] feat: When a driver left the training early, the user should be able to mark the driver. So the app automatically skips the driver. This can be done by eg. adding a checkbox. It should be possible to "re-enable" the driver, in case the user marked the driver by accident or the driver wants to continue the training later. Also drivers, that left the training should be "grayed out" in the UI, so the user can easily see which drivers are still active in the training and which drivers left the training.
 - [x] feat: Add a "trainings view" route where the user can see all trainings that have been created. In this view, the user can also delete trainings.
 - [x] feat: Make laps per stint optional. Currently we need to pass many invalid laps, if the driver is doing less laps then the configured laps per stint. Since this can be common in trainings. We could set the laps per stint to `Infinity`. The UI then should only show the current lap instead of 1 / x laps.
 - [x] feat: Add light and dark mode to the app. (PR #11)

--- a/renderer/hooks/useTraining.ts
+++ b/renderer/hooks/useTraining.ts
@@ -201,7 +201,7 @@ const useTraining = () => {
     notifyInfo('Stint beendet', 'Der Stint wurde beendet.');
   };
 
-  const handleAddDriver = (driver: DriverWithStints) => {
+  const handleAddDriver = (driver: TrainingDriver) => {
     const exists = settings.values.drivers.some((d) => d.uuid === driver.uuid);
     const updatedDrivers = exists
       ? settings.values.drivers.filter((d) => d.uuid !== driver.uuid)
@@ -289,6 +289,14 @@ const useTraining = () => {
     }
 
     updateCurrentStateToNextDriver();
+  };
+
+  const toggleDriverActiveState = (driverUuid: string) => {
+    settings.setFieldValue('drivers', (prevDrivers) =>
+      prevDrivers.map((driver) =>
+        driver.uuid === driverUuid ? { ...driver, isActive: !driver.isActive } : driver,
+      ),
+    );
   };
 
   const handleStopTraining = () => {
@@ -466,6 +474,7 @@ const useTraining = () => {
       addDriver: handleAddDriver,
       updateCurrentDriver: handleUpdateCurrentDriver,
       skipDriver: handleSkipDriver,
+      toggleDriverActive: toggleDriverActiveState,
       stopTraining: handleStopTraining,
       updateLapCones,
       updateLapGates,

--- a/renderer/lib/training/trainingReducer.ts
+++ b/renderer/lib/training/trainingReducer.ts
@@ -5,9 +5,9 @@ import { TIME_PENALTIES_JKS, TIME_PENALTIES_SKS } from '@/lib/constants';
 // =========================
 
 export type TrainingState = {
-  drivers: DriverWithStints[];
+  drivers: TrainingDriver[];
   currentDriverIndex: number;
-  currentDriver?: DriverWithStints;
+  currentDriver?: TrainingDriver;
 
   laps: Lap[];
   currentLap: number;
@@ -26,7 +26,7 @@ export type TrainingAction =
   | { type: 'RESET' }
   | { type: 'SKIP' }
   | { type: 'TICK'; payload: number }
-  | { type: 'SET_DRIVERS'; payload: DriverWithStints[] }
+  | { type: 'SET_DRIVERS'; payload: TrainingDriver[] }
   | { type: 'SET_LAPS_PER_STINT'; payload: number }
   | { type: 'SET_UNLIMITED_LAPS'; payload: boolean }
   | { type: 'SET_MODE'; payload: SlalomType }
@@ -115,7 +115,23 @@ export const trainingReducer = (state: TrainingState, action: TrainingAction): T
     case 'SKIP': {
       if (state.drivers.length === 0) return state;
 
-      const nextIndex = (state.currentDriverIndex + 1) % state.drivers.length;
+      let nextIndex = (state.currentDriverIndex + 1) % state.drivers.length;
+
+      // When the next driver is not active, increase by one more until we find an
+      // active driver or loop back to the start
+      if (!state.drivers[nextIndex].isActive) {
+        const startingIndex = nextIndex;
+
+        do {
+          nextIndex = (nextIndex + 1) % state.drivers.length;
+        } while (nextIndex !== startingIndex && !state.drivers[nextIndex].isActive);
+
+        // If we looped back to the starting index and didn't find any active driver,
+        // return the current state
+        if (!state.drivers[nextIndex].isActive) {
+          return state;
+        }
+      }
 
       return {
         ...state,

--- a/renderer/lib/types/Driver.d.ts
+++ b/renderer/lib/types/Driver.d.ts
@@ -12,6 +12,7 @@ type Driver = {
 /**
  * Extends the default driver profile with an array of laps.
  */
-type DriverWithStints = Driver & {
+type TrainingDriver = Driver & {
   stints: { laps: Lap[] }[];
+  isActive: boolean; // Indicates that the driver is still participating in the training
 };

--- a/renderer/lib/types/Training.d.ts
+++ b/renderer/lib/types/Training.d.ts
@@ -4,7 +4,7 @@ type Training = {
   lapsPerStint: number;
   unlimitedLapsPerStint: boolean;
   mode: TrainingMode;
-  drivers: DriverWithStints[];
+  drivers: TrainingDriver[];
   uuid: string; // UUID v4
   createdAt: number; // Unix timestamp
   updatedAt: number; // Unix timestamp

--- a/renderer/pages/trainings/active.tsx
+++ b/renderer/pages/trainings/active.tsx
@@ -113,6 +113,7 @@ const ActiveTrainingPage = () => {
                     actions.addDriver({
                       ...driver,
                       stints: existing ? existing.stints : [],
+                      isActive: existing ? existing.isActive : true,
                     });
                   }}
                 >
@@ -307,6 +308,7 @@ const ActiveTrainingPage = () => {
                             <Table.Tr>
                               <Table.Th>Fahrer</Table.Th>
                               <Table.Th>Kart</Table.Th>
+                              <Table.Th>Fährt noch</Table.Th>
                             </Table.Tr>
                           </Table.Thead>
                           <Table.Tbody>
@@ -315,11 +317,23 @@ const ActiveTrainingPage = () => {
                                 key={driver.uuid}
                                 bg={currentStint.currentDriverIndex === _idx ? 'blue' : undefined}
                                 c={currentStint.currentDriverIndex === _idx ? 'white' : undefined}
+                                style={{
+                                  opacity: driver.isActive ? 1 : 0.3,
+                                  transition: 'opacity 150ms ease',
+                                }}
                               >
                                 <Table.Td>
                                   {driver.firstName} {driver.lastName}
                                 </Table.Td>
                                 <Table.Td>N/A</Table.Td>
+                                <Table.Td>
+                                  <Checkbox
+                                    checked={driver.isActive}
+                                    onChange={() => {
+                                      actions.toggleDriverActive(driver.uuid);
+                                    }}
+                                  />
+                                </Table.Td>
                               </Table.Tr>
                             ))}
                           </Table.Tbody>

--- a/renderer/pages/trainings/active.tsx
+++ b/renderer/pages/trainings/active.tsx
@@ -328,6 +328,7 @@ const ActiveTrainingPage = () => {
                                 <Table.Td>N/A</Table.Td>
                                 <Table.Td>
                                   <Checkbox
+                                    disabled={currentStint.currentDriverIndex === _idx}
                                     checked={driver.isActive}
                                     onChange={() => {
                                       actions.toggleDriverActive(driver.uuid);

--- a/renderer/pages/trainings/active.tsx
+++ b/renderer/pages/trainings/active.tsx
@@ -36,7 +36,6 @@ import {
   IconUserMinus,
   IconUserPlus,
 } from '@tabler/icons-react';
-import ScrollableTable from '@/components/shared/SortableTable';
 import useTraining from '@/hooks/useTraining';
 import {
   getAverageLap,
@@ -329,73 +328,76 @@ const ActiveTrainingPage = () => {
                     )}
                   </Tabs.Panel>
                   <Tabs.Panel value="fastestLaps" my="lg">
-                    <ScrollableTable
-                      striped
-                      highlightOnHover
-                      withRowBorders={false}
-                      data={{
-                        head: [
-                          'Position',
-                          'Fahrer',
-                          'Kart',
-                          'Rundenzeit',
-                          'Diff.',
-                          'Strafen',
-                          'Zeitpunkt',
-                          'Runden',
-                        ],
-                        body: (() => {
-                          const driversWithFastest = getDriverRanking(settings.values.drivers);
-                          const bestTime = driversWithFastest[0]?.fastestLapTime;
+                    <Table.ScrollContainer minWidth="auto" maxHeight={600}>
+                      <Table
+                        striped
+                        highlightOnHover
+                        stickyHeader
+                        withRowBorders={false}
+                        data={{
+                          head: [
+                            'Position',
+                            'Fahrer',
+                            'Kart',
+                            'Rundenzeit',
+                            'Diff.',
+                            'Strafen',
+                            'Zeitpunkt',
+                            'Runden',
+                          ],
+                          body: (() => {
+                            const driversWithFastest = getDriverRanking(settings.values.drivers);
+                            const bestTime = driversWithFastest[0]?.fastestLapTime;
 
-                          return driversWithFastest.map(
-                            ({ driver, fastestLap, fastestLapTime }, idx) => {
-                              const pos = `${idx + 1}.`;
-                              const name = `${driver.firstName} ${driver.lastName}`;
-                              const kart = (driver as any).kart ?? 'N/A';
-                              const cones = fastestLap?.cones ?? 0;
-                              const gates = fastestLap?.gates ?? 0;
-                              const penalties =
-                                fastestLap !== undefined
-                                  ? `${cones}P ${gates}T (+${getLapPenaltySeconds(
-                                      fastestLap,
-                                      timePenalties,
-                                    )}s)`
-                                  : 'N/A';
-                              const timeStr = fastestLap
-                                ? formatTime(fastestLap.time_with_penalties, 'lap')
-                                : 'N/A';
-
-                              const diffToBest =
-                                fastestLapTime !== undefined
-                                  ? idx === 0 || bestTime === undefined
-                                    ? '-'
-                                    : `${formatTime(fastestLapTime - bestTime, 'gap')}`
+                            return driversWithFastest.map(
+                              ({ driver, fastestLap, fastestLapTime }, idx) => {
+                                const pos = `${idx + 1}.`;
+                                const name = `${driver.firstName} ${driver.lastName}`;
+                                const kart = (driver as any).kart ?? 'N/A';
+                                const cones = fastestLap?.cones ?? 0;
+                                const gates = fastestLap?.gates ?? 0;
+                                const penalties =
+                                  fastestLap !== undefined
+                                    ? `${cones}P ${gates}T (+${getLapPenaltySeconds(
+                                        fastestLap,
+                                        timePenalties,
+                                      )}s)`
+                                    : 'N/A';
+                                const timeStr = fastestLap
+                                  ? formatTime(fastestLap.time_with_penalties, 'lap')
                                   : 'N/A';
 
-                              const date = fastestLap
-                                ? new Date(fastestLap.timestamp).toTimeString().split(' ')[0]
-                                : 'N/A';
+                                const diffToBest =
+                                  fastestLapTime !== undefined
+                                    ? idx === 0 || bestTime === undefined
+                                      ? '-'
+                                      : `${formatTime(fastestLapTime - bestTime, 'gap')}`
+                                    : 'N/A';
 
-                              const totalRounds = (driver.stints ?? []).flatMap(
-                                (stint) => stint.laps ?? [],
-                              ).length;
+                                const date = fastestLap
+                                  ? new Date(fastestLap.timestamp).toTimeString().split(' ')[0]
+                                  : 'N/A';
 
-                              return [
-                                pos,
-                                name,
-                                kart,
-                                timeStr,
-                                diffToBest,
-                                penalties,
-                                date,
-                                totalRounds,
-                              ];
-                            },
-                          );
-                        })(),
-                      }}
-                    />
+                                const totalRounds = (driver.stints ?? []).flatMap(
+                                  (stint) => stint.laps ?? [],
+                                ).length;
+
+                                return [
+                                  pos,
+                                  name,
+                                  kart,
+                                  timeStr,
+                                  diffToBest,
+                                  penalties,
+                                  date,
+                                  totalRounds,
+                                ];
+                              },
+                            );
+                          })(),
+                        }}
+                      />
+                    </Table.ScrollContainer>
                   </Tabs.Panel>
                 </Tabs>
               </Stack>


### PR DESCRIPTION
This pull request implements the ability to mark drivers as inactive if they leave a training session early, allowing users to skip them automatically, visually indicate their inactive status in the UI, and re-enable them if needed. It also updates the relevant data structures and UI to support this feature.

**Driver activity management:**

* Added an `isActive` property to `TrainingDriver` and updated all driver-related types and actions to use `TrainingDriver` instead of `DriverWithStints` throughout the codebase. [[1]](diffhunk://#diff-1137bd5f5378907785b137219eb83016e21d2bf50e4319a5cd6f4735a0602b0dL8-R10) [[2]](diffhunk://#diff-1137bd5f5378907785b137219eb83016e21d2bf50e4319a5cd6f4735a0602b0dL29-R29) [[3]](diffhunk://#diff-262d3e0154db01f5589a5c8e70e3ecb84cdfee496d7f9fbb9b6843cfbdbc3d0fL204-R204) [[4]](diffhunk://#diff-0237c37374e8b71a5d681d4c839c3400720f05474d64983a2978c3e67cfeff55R116)
* Implemented a `toggleDriverActiveState` function in `useTraining` to allow toggling a driver's active status, and exposed it via the hook's actions. [[1]](diffhunk://#diff-262d3e0154db01f5589a5c8e70e3ecb84cdfee496d7f9fbb9b6843cfbdbc3d0fR294-R301) [[2]](diffhunk://#diff-262d3e0154db01f5589a5c8e70e3ecb84cdfee496d7f9fbb9b6843cfbdbc3d0fR477)
* Updated the reducer's `'SKIP'` action to only select the next active driver, looping as needed, and preventing infinite loops if all drivers are inactive.

**User interface enhancements:**

* Updated the active training table to display an "active" checkbox for each driver, allowing users to mark drivers as inactive or re-enable them, and visually "gray out" inactive drivers by reducing row opacity. [[1]](diffhunk://#diff-0237c37374e8b71a5d681d4c839c3400720f05474d64983a2978c3e67cfeff55R311) [[2]](diffhunk://#diff-0237c37374e8b71a5d681d4c839c3400720f05474d64983a2978c3e67cfeff55R320-R336)
* Improved the fastest laps table by using a scrollable container for better usability. [[1]](diffhunk://#diff-0237c37374e8b71a5d681d4c839c3400720f05474d64983a2978c3e67cfeff55L332-R349) [[2]](diffhunk://#diff-0237c37374e8b71a5d681d4c839c3400720f05474d64983a2978c3e67cfeff55R414)

**Documentation:**

* Marked the "skip inactive drivers" feature as complete in `TODO.md`.